### PR TITLE
Fix: Use WebSocket.readyState to check liveSession state

### DIFF
--- a/server.js
+++ b/server.js
@@ -89,7 +89,9 @@ wss.on('connection', async (ws) => {
     ws.on('message', (message) => {
         // This receives messages from the client (our web app)
         // Assuming client sends raw binary audio data (ArrayBuffer)
-        if (liveSession && liveSession.isOpen()) {
+        // The liveSession object from @google/genai v1.3.0 uses a standard WebSocket connection.
+        // .isOpen() is not a valid method; .conn.readyState is used instead.
+        if (liveSession && liveSession.conn.readyState === WebSocket.OPEN) {
             if (message instanceof Buffer) { // Check if message is Buffer (binary data)
                 // The client-side already converts to 16-bit PCM, 16kHz, mono.
                 // The Live API expects base64 encoded audio data.


### PR DESCRIPTION
The liveSession object from the @google/genai library (v1.3.0) does not have an `isOpen()` method. Instead, it provides a `conn` property which is a standard WebSocket object.

This commit changes the check `liveSession.isOpen()` to `liveSession.conn.readyState === WebSocket.OPEN` to correctly determine if the WebSocket connection to the Live API is open before attempting to send messages. This resolves the TypeError `liveSession.isOpen is not a function`.