### PR TITLE
Fix: Clear client audio buffer on interruption

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -123,6 +123,16 @@ async function startSession() {
                     console.error('Error from server:', message.message);
                     statusDiv.textContent = `Server Error: ${message.message}`;
                     endSession(); // Or handle more gracefully
+                } else if (message.type === 'interruption') {
+                    console.log('Interruption message received from server.');
+                    if (audioPlaybackNode) {
+                        audioPlaybackNode.stop();
+                        audioPlaybackNode.disconnect();
+                        audioPlaybackNode = null;
+                    }
+                    clientPlaybackBuffer = [];
+                    isPlaying = false;
+                    statusDiv.textContent = 'AI playback interrupted.';
                 }
             } catch (e) {
                 console.error("Failed to parse message from server or unknown message type:", event.data, e);

--- a/server.js
+++ b/server.js
@@ -83,6 +83,7 @@ wss.on('connection', async (ws) => {
                         }
                         if (message.serverContent.interrupted) {
                             console.log('AI generation was interrupted.');
+                            ws.send(JSON.stringify({ type: 'interruption' }));
                         }
                     } else if (message.error) {
                         console.error('Live API Error:', message.error.message);


### PR DESCRIPTION
Addresses an issue where client-side audio buffering caused a delay in interruption handling. Even after the Live API detected an interruption and stopped generating new audio, the client would continue to play its buffered audio.

This commit implements the following changes:

1. Server-Side (`server.js`):
    - When the Live API signals an interruption (`message.serverContent.interrupted`), the server now forwards a WebSocket message of type `interruption` to the client.

2. Client-Side (`public/app.js`):
    - A handler for the `interruption` WebSocket message has been added.
    - Upon receiving this message, the client immediately:
        - Stops any currently playing audio.
        - Clears the `clientPlaybackBuffer`. - Sets the `isPlaying` flag to false. - Updates the UI to indicate that playback was interrupted.

This ensures that when an interruption occurs, the audio playback on the client stops promptly, providing a much more responsive experience.