### PR TITLE
feat: Add Revolt logo to the header

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <img id="revolt-logo" src="images/revolt_logo_black.png" alt="Revolt Logo">
     <label class="theme-switch-label">
         <input type="checkbox" id="theme-toggle">
         <span class="slider"></span>

--- a/public/style.css
+++ b/public/style.css
@@ -206,3 +206,15 @@ body.dark-mode .slider::before {
 body.dark-mode #theme-toggle:checked + .slider {
     background-color: var(--switch-active-bg-dark);
 }
+
+#revolt-logo {
+    position: fixed;
+    top: 1.5rem;
+    left: 1.5rem;
+    width: 50px;
+    height: auto;
+}
+
+body.dark-mode #revolt-logo {
+    content: url("images/revolt_logo_white.png");
+}


### PR DESCRIPTION
- Added the Revolt logo to the top left corner of the page.
- The logo switches between black and white versions based on the selected theme (light/dark).
- The black logo is used for the light theme, and the white logo is used for the dark theme.