### PR TITLE
feat: Implement 120s inactivity session timeout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -186,6 +186,11 @@ async function startSession() {
                     console.log('AI turn complete - flushing remaining audio');
                     audioStreamEnded = true;
                     flushRemainingAudio();
+                } else if (message.type === 'session_timeout') {
+                    console.log('Session timeout message received from server:', message.message);
+                    // Optionally, display a more user-friendly message on the UI, e.g., by updating a status div
+                    alert(message.message || 'Session ended due to inactivity.'); // Simple alert for now
+                    endSessionCleanup(); // Call existing cleanup function
                 }
             } catch (e) {
                 console.error("Failed to parse message from server or unknown message type:", event.data, e);


### PR DESCRIPTION
Adds a 120-second timer to automatically end the AI session if no AI turn completes within that period.

Changes:
- server.js:
    - Initializes a timer when an AI turn completes.
    - If the timer expires, it sends a 'session_timeout' message to the client and closes the Live API session.
    - The timer is cleared if the session is closed for other reasons (client disconnect, errors, new session start).
- public/app.js:
    - Handles the 'session_timeout' message from the server.
    - Displays an alert to you.
    - Calls endSessionCleanup() to reset the client-side state.