### PR TITLE
Fix: Start session timer on session open and reset on turn complete

### DIFF
--- a/server.js
+++ b/server.js
@@ -65,7 +65,15 @@ wss.on('connection', async (ws) => {
                     console.log('Live API session opened.');
                     isLiveSessionOpen = true; // Set the flag
                     ws.send(JSON.stringify({ type: 'status', message: 'AI session opened.' }));
-                    if (sessionTimeoutId) { clearTimeout(sessionTimeoutId); sessionTimeoutId = null; console.log('Cleared existing session timer on new session open.'); }
+                    if (sessionTimeoutId) { clearTimeout(sessionTimeoutId); console.log('Cleared existing session timer on new session open.'); } // Existing line
+                    // Add the new timer start here
+                    sessionTimeoutId = setTimeout(() => {
+                        console.log('Session timeout: 120 seconds of inactivity after session opened. Closing session.');
+                        ws.send(JSON.stringify({ type: 'session_timeout', message: 'Session ended due to 120 seconds of inactivity.' }));
+                        if (liveSession) { liveSession.close(); }
+                        sessionTimeoutId = null;
+                    }, 120000); // 120 seconds
+                    console.log('Session timer started on AI session open.'); // Added log
                 },
                 onmessage: (message) => {
                     if (message.data) { // Audio data from AI


### PR DESCRIPTION
The 120-second session inactivity timer will now start as soon as our session is successfully opened. Previously, the timer would only start after our first exchange was completed.

This change ensures that sessions will time out correctly even if you start a session but do not send any audio or interact.

The timer will also continue to reset after each exchange, maintaining the existing behavior for active sessions.